### PR TITLE
Removing reverseproxy

### DIFF
--- a/environment
+++ b/environment
@@ -26,11 +26,11 @@ INFRA_REPOS='gogs jenkins'
 
 # Integration test project
 INTEGRATION='integration'
-INTEGRATION_REPOS='broker restapis emailroute reverseproxy db-paas webserver'
+INTEGRATION_REPOS='broker restapis emailroute db-paas webserver'
 
 # Production project
 PROD='prod'
-PROD_REPOS='broker restapis emailroute reverseproxy db-iaas webserver'
+PROD_REPOS='broker restapis emailroute db-iaas webserver'
 
 # Endpoints for IaaS-based MySQL
 IAAS_MYSQL_IP=


### PR DESCRIPTION
Removing the reverse proxy from the INTEGRATION_REPOS and PROD_REPOS as it no longer is in the MONSTER_REPOS list so won't get cloned.
