### PR TITLE
Move service account creation

### DIFF
--- a/bin/go.sh
+++ b/bin/go.sh
@@ -51,6 +51,10 @@ for proj in $PROD; do
   done
 done
 
+# serviceAccount required for containers running as root, before infra project creation as needed for Gogs to start.
+echo '{"kind": "ServiceAccount", "apiVersion": "v1", "metadata": {"name": "root"}}' | sudo oc create -n infra -f -
+(sudo oc get -o yaml scc privileged; echo - system:serviceaccount:infra:root) | sudo oc update scc privileged -f -
+
 for proj in $INFRA; do
   sudo oadm new-project $proj --admin=$DEMOUSER
   oc project $proj
@@ -60,6 +64,3 @@ for proj in $INFRA; do
   done
 done
 
-# serviceAccount required for containers running as root
-echo '{"kind": "ServiceAccount", "apiVersion": "v1", "metadata": {"name": "root"}}' | sudo oc create -n infra -f -
-(sudo oc get -o yaml scc privileged; echo - system:serviceaccount:infra:root) | sudo oc update scc privileged -f -

--- a/bin/go.sh
+++ b/bin/go.sh
@@ -57,7 +57,7 @@ for proj in $INFRA; do
   oc project $proj
 
   # serviceAccount required for containers running as root, before infra project creation as needed for Gogs to start.
-  echo '{"kind": "ServiceAccount", "apiVersion": "v1", "metadata": {"name": "root"}}' | sudo oc create -n infra -f -
+  echo '{"kind": "ServiceAccount", "apiVersion": "v1", "metadata": {"name": "root"}}' | sudo oc create -n $proj -f -
   (sudo oc get -o yaml scc privileged; echo - system:serviceaccount:infra:root) | sudo oc update scc privileged -f -
 
   for repo in $INFRA_REPOS; do

--- a/bin/go.sh
+++ b/bin/go.sh
@@ -51,13 +51,14 @@ for proj in $PROD; do
   done
 done
 
-# serviceAccount required for containers running as root, before infra project creation as needed for Gogs to start.
-echo '{"kind": "ServiceAccount", "apiVersion": "v1", "metadata": {"name": "root"}}' | sudo oc create -n infra -f -
-(sudo oc get -o yaml scc privileged; echo - system:serviceaccount:infra:root) | sudo oc update scc privileged -f -
 
 for proj in $INFRA; do
   sudo oadm new-project $proj --admin=$DEMOUSER
   oc project $proj
+
+  # serviceAccount required for containers running as root, before infra project creation as needed for Gogs to start.
+  echo '{"kind": "ServiceAccount", "apiVersion": "v1", "metadata": {"name": "root"}}' | sudo oc create -n infra -f -
+  (sudo oc get -o yaml scc privileged; echo - system:serviceaccount:infra:root) | sudo oc update scc privileged -f -
 
   for repo in $INFRA_REPOS; do
     infra/$repo/deploy.sh


### PR DESCRIPTION
Moved the service account creation part to inside of the infrastructure creation loop. Otherwise the install hangs waiting on the gogs container that will not start.
