### PR TITLE
Updated the remote origin to use the Service IP and http

### DIFF
--- a/bin/push-gogs.sh
+++ b/bin/push-gogs.sh
@@ -10,9 +10,10 @@ callback() {
 
   pushd $1/$2 &>/dev/null
   git remote rm origin
-  git remote add origin ssh://git@localhost:2222/$INTEGRATION/$(basename $(realpath .))
+  git remote add origin http://administrator:$DEMOPW@$SVCIP/$INTEGRATION/$(basename $(realpath .))
   GIT_SSH=../../bin/issh git push -u origin master
   popd &>/dev/null
 }
 
+SVCIP=$(oc get services gogs -o template --template='{{.spec.portalIP}}')
 all_repos "$MONSTER_REPOS" monster callback


### PR DESCRIPTION
Solves issue #3

Updated the push-gogs.sh to use the service ip address instead of localhost and also use http instead of ssh.

You could still use ssh if the service was modified to expose port 22. 

The reason I am not using the route is there appears to be some issues cloning/pushing to the route (GOGS logs show Bad protocol version identification). 
